### PR TITLE
Fix "Bad Request" error for unpushable devices

### DIFF
--- a/src/PHPushbullet.php
+++ b/src/PHPushbullet.php
@@ -126,7 +126,9 @@ class PHPushbullet
     public function all()
     {
         foreach ($this->devices() as $device) {
-            $this->devices[] = $device->iden;
+            if($device->pushable == true) {
+                $this->devices[] = $device->iden;
+            }
         }
 
         return $this;


### PR DESCRIPTION
I had this error because one of my device was "unpushable"

>[GuzzleHttp\Exception\ClientException]                                                                
>Client error response [url] https://api.pushbullet.com/v2/pushes [status code] 400 [reason phrase] Bad >Request
<img width="344" alt="capture d ecran 2015-09-04 a 18 08 55" src="https://cloud.githubusercontent.com/assets/6841201/9688570/3f50f5e2-5330-11e5-8dbe-6704047d49de.png">
