### PR TITLE
Fluent methods now accept arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ To push to multiple devices:
 $pushbullet->device('Chrome')->device('Galaxy S4')->note('Remember', 'Buy some eggs.');
 // or
 $pushbullet->device('Chrome', 'Galaxy S4')->note('Remember', 'Buy some eggs.');
+// or
+$pushbullet->device(['Chrome', 'Galaxy S4'])->note('Remember', 'Buy some eggs.');
 ```
 
 ### To Users
@@ -91,6 +93,8 @@ To push to multiple users:
 $pushbullet->user('joe@example.com')->user('anne@example.com')->note('Remember', 'Buy some eggs.');
 // or
 $pushbullet->user('joe@example.com', 'anne@example.com')->note('Remember', 'Buy some eggs.');
+// or
+$pushbullet->user(['joe@example.com', 'anne@example.com'])->note('Remember', 'Buy some eggs.');
 ```
 ## Types
 

--- a/src/PHPushbullet.php
+++ b/src/PHPushbullet.php
@@ -79,7 +79,13 @@ class PHPushbullet
 
     public function user()
     {
-        $this->users = array_merge(func_get_args(), $this->users);
+        if (is_array(func_get_arg(0))) {
+            $users = func_get_arg(0);
+        } else {
+            $users = func_get_args();
+        }
+
+        $this->users = array_merge($users, $this->users);
         $this->users = array_filter($this->users);
         $this->users = array_unique($this->users);
 
@@ -93,7 +99,13 @@ class PHPushbullet
      */
     public function device()
     {
-        foreach (func_get_args() as $destination) {
+        if (is_array(func_get_arg(0))) {
+            $devices = func_get_arg(0);
+        } else {
+            $devices = func_get_args();
+        }
+
+        foreach ($devices as $destination) {
             $device = $this->getDeviceIden($destination);
 
             if (!$device) {
@@ -113,7 +125,13 @@ class PHPushbullet
      */
     public function channel()
     {
-        $this->channels = array_merge(func_get_args());
+        if (is_array(func_get_arg(0))) {
+            $channels = func_get_arg(0);
+        } else {
+            $channels = func_get_args();
+        }
+
+        $this->channels = array_merge($channels);
 
         return $this;
     }


### PR DESCRIPTION
Fluent methods can now accept an array as argument, avoiding usage of
foreach to push the `devices` or `users`.

No error during the tests