### PR TITLE
Options can be passed to constructor

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -21,9 +21,9 @@ class Connection
      */
     protected $client;
 
-    public function __construct($access_token, Client $client = null)
+    public function __construct($access_token, Client $client = null, array $config = [])
     {
-        $this->client = $client ?: new Client($this->getClientParams($access_token));
+        $this->client = $client ?: new Client($this->getClientParams($access_token, $config));
     }
 
     /**
@@ -34,7 +34,7 @@ class Connection
         return $this->client;
     }
 
-    protected function getClientParams($access_token)
+    protected function getClientParams($access_token, array $config = [])
     {
         $headers = [
             'Access-Token' => $access_token,
@@ -42,15 +42,18 @@ class Connection
         ];
 
         if (version_compare(Client::VERSION, 6, '>=')) {
-            return [
+            return array_replace([
                 'base_uri' => $this->base_url,
                 'headers'  => $headers,
-            ];
+            ], $config);
         }
 
         return [
             'base_url' => [$this->base_url, []],
-            'defaults' => ['headers'  => $headers],
+            'defaults' => array_replace(
+                            ['headers'  => $headers],
+                            $config
+            ),
         ];
     }
 }

--- a/src/PHPushbullet.php
+++ b/src/PHPushbullet.php
@@ -48,7 +48,7 @@ class PHPushbullet
      */
     protected $all_devices = [];
 
-    public function __construct($access_token = null, Connection $connection =  null)
+    public function __construct($access_token = null, Connection $connection =  null, array $config = [])
     {
         $access_token = $access_token ?: getenv('pushbullet.access_token');
 
@@ -56,7 +56,7 @@ class PHPushbullet
             throw new \Exception('Your Pushbullet access token is not set.');
         }
 
-        $connection = $connection ?: new Connection($access_token);
+        $connection = $connection ?: new Connection($access_token, null, $config);
 
         $this->api = $connection->client();
     }


### PR DESCRIPTION
On `Guzzle 6`, default options can’t be set outside the constructor.
Passing options to the constructor is working on `5.3` and `6.0`
